### PR TITLE
Apt package to install python2.7 for ansible

### DIFF
--- a/prod/roles/common/tasks/01_server.yml
+++ b/prod/roles/common/tasks/01_server.yml
@@ -4,6 +4,7 @@
   apt: name={{item}} state=latest
   become: yes
   with_items:
+    - python
     - python-pip
     - python-dev
     - libpq-dev


### PR DESCRIPTION
Just read that ansible is still natively working alongside python2.7. So I added it as an initial installation package using apt if the server OS only had python3 pre-installed.